### PR TITLE
Fix Jena SHACL invocation

### DIFF
--- a/validate_shacl_35_OCP.py
+++ b/validate_shacl_35_OCP.py
@@ -183,13 +183,7 @@ def perform_shacl_jena_validation(data_file, shapes_path=OCP_SHAPES_PATH):
         bool: True if the data conforms to the SHACL shapes, False otherwise.
     """
     try:
-        # Check if Jena SHACL tool exists
-        jena_shacl_cmd = os.path.join(JENA_HOME, "bat", "shacl.bat") if os.name == 'nt' else os.path.join(JENA_HOME, "bin", "shacl")
-        if not os.path.exists(jena_shacl_cmd):
-            logger.error(f"Jena SHACL-Tool not found: {jena_shacl_cmd}")
-            return False
-
-        # Create log4j2.properties to avoid URL errors
+        # Ensure log4j2.properties exists and use it explicitly as a file URI
         log4j_props = os.path.join(JENA_HOME, "log4j2.properties")
         if not os.path.exists(log4j_props):
             with open(log4j_props, "w", encoding="utf-8") as f:
@@ -210,10 +204,26 @@ rootLogger.appenderRef.stdout.ref = STDOUT
 """)
             logger.debug(f"Created Log4j2 properties: {log4j_props}")
 
-        # Prepare command for Jena SHACL validation
+        # Build command to invoke Jena SHACL via Java to avoid batch file issues
+        java_exec = JAVA_EXE if os.name == 'nt' else "java"
+        classpath = os.path.join(JENA_HOME, "lib", "*")
+        log4j_uri = f"file:///{log4j_props.replace(os.sep, '/')}"
+
         data_file_jena = data_file.replace("\\", "/")
         shapes_path_jena = shapes_path.replace("\\", "/")
-        cmd = [jena_shacl_cmd, "validate", "--data", data_file_jena, "--shapes", shapes_path_jena]
+
+        cmd = [
+            java_exec,
+            f"-Dlog4j.configurationFile={log4j_uri}",
+            "-cp",
+            classpath,
+            "shacl.shacl",
+            "validate",
+            "--data",
+            data_file_jena,
+            "--shapes",
+            shapes_path_jena,
+        ]
         
         # Run validation and save report
         report_file = os.path.join(BASE_DIR, "validation_report.ttl").replace("\\", "/")


### PR DESCRIPTION
## Summary
- call Apache Jena SHACL validator using Java directly
- ensure log4j2 properties path is provided as file URI

## Testing
- `python validate_shacl_35_OCP.py` *(fails: ModuleNotFoundError: No module named 'rdflib')*

------
https://chatgpt.com/codex/tasks/task_e_6840670cd5d4832cb82a33f93abe116a